### PR TITLE
Replace deprecated `update_attributes`

### DIFF
--- a/lib/easy/reference_data/refresh.rb
+++ b/lib/easy/reference_data/refresh.rb
@@ -19,7 +19,7 @@ module Easy
       end
 
       begin
-        record.update_attributes!(attributes)
+        record.update!(attributes)
       rescue
         $stderr.puts "Save failed for #{record.class} with attributes #{attributes.inspect}"
         raise


### PR DESCRIPTION
Rails 6 has deprecated `update_attributes` so we should use
`update` instead.

This will make the gem incompatible with rails apps below rails 4
so I wouldn't suggest applying this change without some more thinking

https://blog.saeloun.com/2019/04/15/rails-6-deprecates-update-attributes.html