### PR TITLE
Replace deprecated update_attributes! with update!

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+1.2.0 - 2021-05-27
+
+  Bug fixes
+
+    * Replace Rails 6.1 deprecated `update_attributes!` with `update!`
+
 1.1.0 - 2019-02-05
 
   Enhancements

--- a/easy_reference_data.gemspec
+++ b/easy_reference_data.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rails', '>= 3.0.0'
 
   gem.add_development_dependency 'rspec', '~> 3.6.0'
-  gem.add_development_dependency 'sqlite3', '~> 1.3.0'
+  gem.add_development_dependency 'sqlite3', '~> 1.4.0'
   gem.add_development_dependency 'database_cleaner', '~> 1.6'
 end

--- a/lib/easy/reference_data/refresh.rb
+++ b/lib/easy/reference_data/refresh.rb
@@ -19,7 +19,7 @@ module Easy
       end
 
       begin
-        record.update_attributes!(attributes)
+        record.update!(attributes)
       rescue
         $stderr.puts "Save failed for #{record.class} with attributes #{attributes.inspect}"
         raise

--- a/lib/easy/reference_data/version.rb
+++ b/lib/easy/reference_data/version.rb
@@ -1,5 +1,5 @@
 module Easy
   module ReferenceData
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end


### PR DESCRIPTION
The `update_attributes*` methods have been soft deprecated
since 2013 and hard deprecated in Rails 6.1:
NoMethodError: undefined method `update_attributes!'

The `update` and `update!` methods should be used instead.